### PR TITLE
feat(native-pos): Two-phase memory reclaim for MaterializedOutputBuff…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <dep.fastutil.version>8.5.2</dep.fastutil.version>
         <dep.datasketches-memory.version>2.2.0</dep.datasketches-memory.version>
         <dep.datasketches-java.version>5.0.1</dep.datasketches-java.version>
-        <dep.io.opentelemetry.version>1.58.0</dep.io.opentelemetry.version>
+        <dep.io.opentelemetry.version>1.62.0</dep.io.opentelemetry.version>
 
         <release.autoPublish>true</release.autoPublish>
     </properties>

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -241,6 +241,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(
               kExchangeMaterializationOutputBufferPerPartitionMaxBytes,
               130L * 1024),
+          NUM_PROP(kExchangeMaterializationReclaimDrainThresholdRatio, 0.67),
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
           STR_PROP(kRemoteFunctionServerSerde, "presto_page"),
           BOOL_PROP(kHttpEnableAccessLog, false),
@@ -798,6 +799,12 @@ int64_t SystemConfig::exchangeMaterializationOutputBufferPerPartitionMaxBytes()
   return optionalProperty<int64_t>(
              kExchangeMaterializationOutputBufferPerPartitionMaxBytes)
       .value_or(130L * 1024);
+}
+
+double SystemConfig::exchangeMaterializationReclaimDrainThresholdRatio() const {
+  return optionalProperty<double>(
+             kExchangeMaterializationReclaimDrainThresholdRatio)
+      .value_or(0.67);
 }
 
 bool SystemConfig::enableSerializedPageChecksum() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -693,6 +693,17 @@ class SystemConfig : public ConfigBase {
       kExchangeMaterializationOutputBufferPerPartitionMaxBytes{
           "exchange.materialization.output-buffer.per-partition-max-bytes"};
 
+  /// Fraction of the per-partition drain threshold used during memory reclaim.
+  /// The reclaim drain threshold is generally lower than the regular drain
+  /// threshold, but high enough that draining actually reduces memory. Without
+  /// this lower bound, reclaim would flush small partition buffers that don't
+  /// produce compressible packages — low ROI flushes that move data to the
+  /// writer without freeing meaningful memory.
+  /// Default: 0.67.
+  static constexpr std::string_view
+      kExchangeMaterializationReclaimDrainThresholdRatio{
+          "exchange.materialization.reclaim-drain-threshold-ratio"};
+
   static constexpr std::string_view kHttpEnableAccessLog{
       "http-server.enable-access-log"};
   static constexpr std::string_view kHttpEnableStatsFilter{
@@ -1159,6 +1170,8 @@ class SystemConfig : public ConfigBase {
   int64_t exchangeMaterializationOutputBufferMaxBytes() const;
 
   int64_t exchangeMaterializationOutputBufferPerPartitionMaxBytes() const;
+
+  double exchangeMaterializationReclaimDrainThresholdRatio() const;
 
   bool enableSerializedPageChecksum() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.cpp
@@ -18,10 +18,22 @@
 #include <folly/ExceptionString.h>
 #include <glog/logging.h>
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <memory>
+#include <numeric>
+#include <thread>
 
+#include "presto_cpp/main/common/Configs.h"
 #include "velox/common/base/Exceptions.h"
+
+#define MATERIALIZED_BUFFER_LOG(logEvent, pool, fmt_str, ...)           \
+  LOG(INFO) << fmt::format(                                             \
+      "MaterializedOutputBuffer::{} pool={} poolUsedBytes={} " fmt_str, \
+      logEvent,                                                         \
+      (pool)->name(),                                                   \
+      velox::succinctBytes((pool)->usedBytes()),                        \
+      ##__VA_ARGS__)
 
 namespace facebook::presto::operators {
 
@@ -62,7 +74,7 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
   // Drain: coalesce + flush under the same lock.
   std::deque<std::unique_ptr<folly::IOBuf>> toDrain;
   toDrain.swap(rowGroups_);
-  auto drainedBytes = bufferedBytes_;
+  auto drainedBytes = bufferedBytes_.load();
   bufferedBytes_ = 0;
 
   auto coalesced = buffer_->coalesceRowGroups(toDrain);
@@ -70,28 +82,7 @@ int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
   return drainedBytes;
 }
 
-MaterializedOutputBuffer::MaterializedOutputBuffer(
-    int32_t numPartitions,
-    const std::string& shuffleWriterInfo,
-    ShuffleInterfaceFactory* shuffleWriterFactory,
-    const std::string& taskId,
-    int64_t maxBufferedBytes,
-    velox::memory::MemoryPool* pool,
-    int64_t partitionDrainThreshold)
-    : numPartitions_(numPartitions),
-      maxBufferedBytes_(maxBufferedBytes),
-      partitionDrainThreshold_(
-          std::min(
-              partitionDrainThreshold > 0 ? partitionDrainThreshold
-                                          : kDefaultDrainThreshold,
-              maxBufferedBytes / numPartitions)),
-      pool_(pool->addLeafChild(
-          fmt::format("materialized_output_buffer.{}", taskId),
-          true,
-          velox::exec::MemoryReclaimer::create())),
-      writer_(
-          shuffleWriterFactory->createWriter(shuffleWriterInfo, pool_.get())),
-      collectCountPerPartition_(numPartitions) {
+void MaterializedOutputBuffer::initPartitionBuffers(int32_t numPartitions) {
   VELOX_CHECK_NOT_NULL(pool_, "MemoryPool must be non-null");
   VELOX_CHECK_NOT_NULL(writer_, "ShuffleWriter must be non-null");
   VELOX_CHECK_GT(numPartitions, 0, "Must have at least one partition");
@@ -102,15 +93,43 @@ MaterializedOutputBuffer::MaterializedOutputBuffer(
             partitionDrainThreshold_, writer_.get(), this));
   }
   LOG(INFO) << fmt::format(
-      "MaterializedOutputBuffer: partitions={}, maxBufferedBytes={}MB, "
-      "effectiveDrainThreshold={}KB (configured={}KB), pool={}",
+      "MaterializedOutputBuffer: partitions={}, maxBufferedBytes={}, "
+      "drainThreshold={}, reclaimDrainThreshold={}, pool={}",
       numPartitions_,
-      maxBufferedBytes_ >> 20,
-      partitionDrainThreshold_ >> 10,
-      (partitionDrainThreshold > 0 ? partitionDrainThreshold
-                                   : kDefaultDrainThreshold) >>
-          10,
+      velox::succinctBytes(maxBufferedBytes_),
+      velox::succinctBytes(partitionDrainThreshold_),
+      velox::succinctBytes(reclaimDrainThresholdBytes_),
       pool_->name());
+}
+
+MaterializedOutputBuffer::MaterializedOutputBuffer(
+    int32_t numPartitions,
+    const std::string& shuffleWriterInfo,
+    ShuffleInterfaceFactory* shuffleWriterFactory,
+    const std::string& taskId,
+    velox::memory::MemoryPool* pool)
+    : numPartitions_(numPartitions),
+      maxBufferedBytes_(
+          SystemConfig::instance()
+              ->exchangeMaterializationOutputBufferMaxBytes()),
+      partitionDrainThreshold_(
+          std::min(
+              SystemConfig::instance()
+                  ->exchangeMaterializationOutputBufferPerPartitionMaxBytes(),
+              maxBufferedBytes_ / numPartitions)),
+      reclaimDrainThresholdBytes_(
+          static_cast<int64_t>(
+              partitionDrainThreshold_ *
+              SystemConfig::instance()
+                  ->exchangeMaterializationReclaimDrainThresholdRatio())),
+      pool_(pool->addLeafChild(
+          fmt::format("materialized_output_buffer.{}", taskId),
+          true,
+          std::make_unique<Reclaimer>(this))),
+      writer_(
+          shuffleWriterFactory->createWriter(shuffleWriterInfo, pool_.get())),
+      collectCountPerPartition_(numPartitions) {
+  initPartitionBuffers(numPartitions);
 }
 
 MaterializedOutputBuffer::~MaterializedOutputBuffer() {
@@ -164,20 +183,18 @@ void MaterializedOutputBuffer::enqueue(
       partitionBuffers_[partition]->enqueue(partition, std::move(rowGroup));
 
   if (drainedBytes > 0) {
-    ++drainCount_;
-    auto totalDrained = (totalDrainedBytes_ += drainedBytes);
-    auto currentGB = totalDrained >> 30;
+    updateDrainStats(drainedBytes);
+    auto currentGB = static_cast<int64_t>(drainedBytes_) >> 30;
     int64_t lastGB = lastLoggedDrainedGB_;
     if (currentGB > lastGB &&
         lastLoggedDrainedGB_.compare_exchange_strong(lastGB, currentGB)) {
       LOG(INFO) << fmt::format(
-          "MaterializedOutputBuffer progress: totalDrained={}GB, "
-          "drainCount={}, bufferedBytes={}MB",
-          currentGB,
+          "MaterializedOutputBuffer progress: drainedBytes={}, "
+          "drainCount={}, bufferedBytes={}",
+          velox::succinctBytes(drainedBytes_),
           static_cast<int64_t>(drainCount_),
-          bufferedBytes_ >> 20);
+          velox::succinctBytes(bufferedBytes_));
     }
-    bufferedBytes_.fetch_sub(drainedBytes);
   }
 }
 
@@ -191,6 +208,12 @@ void MaterializedOutputBuffer::flushToWriter(
   std::string_view view(reinterpret_cast<const char*>(data->data()), dataSize);
   writer_->collect(partition, /*key=*/"", view);
   ++collectCountPerPartition_[partition];
+}
+
+void MaterializedOutputBuffer::updateDrainStats(int64_t drainedBytes) {
+  ++drainCount_;
+  drainedBytes_ += drainedBytes;
+  bufferedBytes_.fetch_sub(drainedBytes);
 }
 
 std::unique_ptr<folly::IOBuf> MaterializedOutputBuffer::coalesceRowGroups(
@@ -211,39 +234,66 @@ std::unique_ptr<folly::IOBuf> MaterializedOutputBuffer::coalesceRowGroups(
 
 int64_t MaterializedOutputBuffer::drainPartition(
     int32_t partition,
-    bool close) {
+    bool force) {
   VELOX_CHECK_GE(partition, 0);
   VELOX_CHECK_LT(partition, numPartitions_);
 
   std::deque<std::unique_ptr<folly::IOBuf>> toDrain;
   int64_t drainedBytes = 0;
   {
-    std::lock_guard<std::mutex> lock(partitionBuffers_[partition]->mutex_);
-    toDrain.swap(partitionBuffers_[partition]->rowGroups_);
-    drainedBytes = partitionBuffers_[partition]->bufferedBytes_;
-    partitionBuffers_[partition]->bufferedBytes_ = 0;
-    if (close) {
+    std::unique_lock<std::mutex> lock(
+        partitionBuffers_[partition]->mutex_, std::defer_lock);
+    if (force) {
+      lock.lock();
       partitionBuffers_[partition]->closed_ = true;
+    } else {
+      lock.try_lock();
+      if (!lock.owns_lock()) {
+        return 0;
+      }
     }
+    toDrain.swap(partitionBuffers_[partition]->rowGroups_);
+    drainedBytes = partitionBuffers_[partition]->bufferedBytes_.exchange(0);
   }
 
   if (!toDrain.empty()) {
     auto coalesced = coalesceRowGroups(toDrain);
     flushToWriter(partition, std::move(coalesced));
-    ++drainCount_;
-    totalDrainedBytes_ += drainedBytes;
-    bufferedBytes_.fetch_sub(drainedBytes);
+    updateDrainStats(drainedBytes);
   }
 
   return drainedBytes;
 }
 
-uint64_t MaterializedOutputBuffer::close() {
-  uint64_t totalDrained = 0;
+uint64_t MaterializedOutputBuffer::tryDrainPartitions() {
+  std::vector<int32_t> orderedPartitions(numPartitions_);
+  std::iota(orderedPartitions.begin(), orderedPartitions.end(), 0);
+
+  std::vector<int64_t> sizes(numPartitions_);
   for (int32_t i = 0; i < numPartitions_; ++i) {
-    totalDrained += drainPartition(i, /*close=*/true);
+    sizes[i] = partitionBuffers_[i]->bufferedBytes_;
   }
-  return totalDrained;
+  std::sort(
+      orderedPartitions.begin(),
+      orderedPartitions.end(),
+      [&](int32_t lhs, int32_t rhs) { return sizes[lhs] > sizes[rhs]; });
+
+  uint64_t drainedBytes = 0;
+  for (auto partition : orderedPartitions) {
+    if (sizes[partition] < reclaimDrainThresholdBytes_) {
+      break;
+    }
+    drainedBytes += drainPartition(partition, /*force=*/false);
+  }
+  return drainedBytes;
+}
+
+uint64_t MaterializedOutputBuffer::close() {
+  uint64_t drainedBytes = 0;
+  for (int32_t i = 0; i < numPartitions_; ++i) {
+    drainedBytes += drainPartition(i, /*force=*/true);
+  }
+  return drainedBytes;
 }
 
 void MaterializedOutputBuffer::noMoreData() {
@@ -252,8 +302,8 @@ void MaterializedOutputBuffer::noMoreData() {
     return;
   }
   LOG(INFO) << fmt::format(
-      "MaterializedOutputBuffer noMoreData: draining, bufferedBytes={}MB",
-      bufferedBytes_ >> 20);
+      "MaterializedOutputBuffer noMoreData: draining, bufferedBytes={}",
+      velox::succinctBytes(bufferedBytes_));
   close();
   LOG(INFO) << "MaterializedOutputBuffer: calling writer noMoreData(true)";
   try {
@@ -269,16 +319,16 @@ void MaterializedOutputBuffer::noMoreData() {
     totalCollects += collectCountPerPartition_[i];
   }
   LOG(INFO) << fmt::format(
-      "MaterializedOutputBuffer progress: totalDrained={}GB, "
-      "drainCount={}, bufferedBytes={}MB",
-      totalDrainedBytes_ >> 30,
+      "MaterializedOutputBuffer progress: drainedBytes={}, "
+      "drainCount={}, bufferedBytes={}",
+      velox::succinctBytes(drainedBytes_),
       static_cast<int64_t>(drainCount_),
-      bufferedBytes_ >> 20);
+      velox::succinctBytes(bufferedBytes_));
   LOG(INFO) << fmt::format(
       "MaterializedOutputBuffer closed: "
-      "collectCalls={}, peakBufferedBytes={}MB",
+      "collectCalls={}, peakBufferedBytes={}",
       totalCollects,
-      peakBufferedBytes_ >> 20);
+      velox::succinctBytes(peakBufferedBytes_));
   state_ = State::kClosed;
 }
 
@@ -316,8 +366,8 @@ MaterializedOutputBuffer::stats() const {
   for (int32_t i = 0; i < numPartitions_; ++i) {
     totalCollects += collectCountPerPartition_[i];
   }
-  result[std::string(kTotalDrainedBytes)] =
-      velox::RuntimeMetric(totalDrainedBytes_, Unit::kBytes);
+  result[std::string(kDrainedBytes)] =
+      velox::RuntimeMetric(drainedBytes_, Unit::kBytes);
   result[std::string(kDrainCount)] = velox::RuntimeMetric(drainCount_);
   result[std::string(kCurrentDrainThreshold)] =
       velox::RuntimeMetric(partitionDrainThreshold_, Unit::kBytes);
@@ -328,7 +378,117 @@ MaterializedOutputBuffer::stats() const {
   result[std::string(kTotalCollectCalls)] = velox::RuntimeMetric(totalCollects);
   result[std::string(kPeakBufferedBytes)] =
       velox::RuntimeMetric(peakBufferedBytes_, Unit::kBytes);
+  result[std::string(kReclaimCount)] = velox::RuntimeMetric(reclaimCount_);
+  result[std::string(kReclaimedBytes)] =
+      velox::RuntimeMetric(reclaimedBytes_, Unit::kBytes);
   return result;
+}
+
+MaterializedOutputBuffer::Reclaimer::Reclaimer(
+    MaterializedOutputBuffer* partitionBuffer)
+    : MemoryReclaimer(kHighReclaimPriority), partitionBuffer_(partitionBuffer) {
+  VELOX_CHECK_NOT_NULL(partitionBuffer_, "Reclaimer requires a buffer");
+}
+
+bool MaterializedOutputBuffer::Reclaimer::reclaimableBytes(
+    const velox::memory::MemoryPool& pool,
+    uint64_t& reclaimableBytes) const {
+  reclaimableBytes = pool.usedBytes();
+  return reclaimableBytes > 0;
+}
+
+void MaterializedOutputBuffer::Reclaimer::tryReclaimPartitionBuffers(
+    velox::memory::MemoryPool* pool) {
+  auto flushedBytes = partitionBuffer_->tryDrainPartitions();
+  MATERIALIZED_BUFFER_LOG(
+      "FLUSH", pool, "flushedBytes={}", velox::succinctBytes(flushedBytes));
+}
+
+void MaterializedOutputBuffer::Reclaimer::waitForWriterDrain(
+    velox::memory::MemoryPool* pool,
+    uint64_t targetUsedBytes,
+    std::chrono::steady_clock::time_point deadline) {
+  while (pool->usedBytes() > targetUsedBytes) {
+    if (std::chrono::steady_clock::now() >= deadline) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  MATERIALIZED_BUFFER_LOG(
+      "WAIT",
+      pool,
+      "targetUsedBytes={} timedOut={}",
+      velox::succinctBytes(targetUsedBytes),
+      pool->usedBytes() > targetUsedBytes);
+}
+
+void MaterializedOutputBuffer::Reclaimer::recordStats(
+    uint64_t freedBytes,
+    Stats& stats) {
+  stats.reclaimedBytes += freedBytes;
+  ++partitionBuffer_->reclaimCount_;
+  partitionBuffer_->reclaimedBytes_ += freedBytes;
+}
+
+bool MaterializedOutputBuffer::Reclaimer::canReclaim(
+    const velox::memory::MemoryPool& pool,
+    uint64_t targetBytes) const {
+  if (targetBytes == 0 || pool.usedBytes() == 0) {
+    return false;
+  }
+  const auto state = partitionBuffer_->state();
+  return state == State::kActive || state == State::kDraining;
+}
+
+bool MaterializedOutputBuffer::Reclaimer::canReclaimFromPartitionBuffers()
+    const {
+  // Only flush partition buffers in kActive state. During kDraining,
+  // noMoreData() is already draining them — we skip to waiting for
+  // writer network drain. The bufferedBytes check avoids a no-op flush
+  // when all data has already been drained by enqueue threshold logic.
+  return partitionBuffer_->state() == State::kActive &&
+      partitionBuffer_->bufferedBytes() > 0;
+}
+
+uint64_t MaterializedOutputBuffer::Reclaimer::reclaim(
+    velox::memory::MemoryPool* pool,
+    uint64_t targetBytes,
+    uint64_t maxWaitMs,
+    Stats& stats) {
+  if (!canReclaim(*pool, targetBytes)) {
+    return 0;
+  }
+
+  auto prevUsedBytes = pool->usedBytes();
+  auto targetUsedBytes =
+      prevUsedBytes > targetBytes ? prevUsedBytes - targetBytes : 0;
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(maxWaitMs);
+
+  MATERIALIZED_BUFFER_LOG(
+      "START",
+      pool,
+      "targetBytes={} maxWaitMs={}",
+      velox::succinctBytes(targetBytes),
+      maxWaitMs);
+
+  // Flush partition buffers to the writer.
+  if (canReclaimFromPartitionBuffers()) {
+    tryReclaimPartitionBuffers(pool);
+    if (pool->usedBytes() <= targetUsedBytes) {
+      auto totalFreedBytes = prevUsedBytes - pool->usedBytes();
+      recordStats(totalFreedBytes, stats);
+      return totalFreedBytes;
+    }
+  }
+
+  // Wait for writer to drain to release memory after flush to network.
+  waitForWriterDrain(pool, targetUsedBytes, deadline);
+
+  auto totalFreedBytes =
+      prevUsedBytes > pool->usedBytes() ? prevUsedBytes - pool->usedBytes() : 0;
+  recordStats(totalFreedBytes, stats);
+  return totalFreedBytes;
 }
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
+++ b/presto-native-execution/presto_cpp/main/operators/MaterializedOutputBuffer.h
@@ -30,22 +30,19 @@
 
 namespace facebook::presto::operators {
 
-/// Shared buffer between MaterializedOutput operators and a ShuffleWriter.
-///
-/// Accepts serialized RowGroups per partition from multiple drivers, buffers
-/// them, and drains to the ShuffleWriter when the per-partition threshold is
-/// hit.
-///
-/// Memory for buffered RowGroups is tracked through bufferPool_ (a system
-/// pool visible for accounting). The writer uses a separate system pool.
 /// Thread-safe shared buffer between MaterializedOutput operators and a
 /// ShuffleWriter. Multiple MaterializedOutput drivers enqueue concurrently;
 /// the buffer drains to the writer when per-partition thresholds are hit.
+///
+/// Memory pressure is handled by the Velox memory arbitrator via the
+/// nested Reclaimer class, not cooperative backpressure.
 ///
 /// Lifecycle state machine:
 ///   kActive -> kDraining -> kClosed  (noMoreData: success)
 ///   kActive -> kDraining -> kAborted (noMoreData: writer failure)
 ///   kActive -> kAborted              (abort: error teardown)
+/// Reclaim Phase 1 (flush partitions) runs only in kActive. Phase 2
+/// (wait for writer network drain) also runs in kClosed.
 class MaterializedOutputBuffer {
  public:
   enum class State : uint8_t {
@@ -59,9 +56,12 @@ class MaterializedOutputBuffer {
 
   static constexpr int64_t kDefaultDrainThreshold = 130L * 1024;
 
+  /// Default fraction of the per-partition drain threshold used during reclaim.
+  static constexpr double kDefaultReclaimDrainThresholdRatio = 0.67;
+
   // Stat name constants.
-  static constexpr std::string_view kTotalDrainedBytes =
-      "materializedOutputBuffer.totalDrainedBytes";
+  static constexpr std::string_view kDrainedBytes =
+      "materializedOutputBuffer.drainedBytes";
   static constexpr std::string_view kDrainCount =
       "materializedOutputBuffer.drainCount";
   static constexpr std::string_view kCurrentDrainThreshold =
@@ -74,6 +74,66 @@ class MaterializedOutputBuffer {
       "materializedOutputBuffer.totalCollectCalls";
   static constexpr std::string_view kPeakBufferedBytes =
       "materializedOutputBuffer.peakBufferedBytes";
+  static constexpr std::string_view kReclaimCount =
+      "materializedOutputBuffer.reclaimCount";
+  static constexpr std::string_view kReclaimedBytes =
+      "materializedOutputBuffer.reclaimedBytes";
+
+  /// Memory reclaimer for the exchange writer pool. Nested inside
+  /// MaterializedOutputBuffer so the raw back-pointer is always valid — the
+  /// pool owns the reclaimer, and MaterializedOutputBuffer owns the pool.
+  ///
+  /// Two-phase reclaim:
+  /// (1) flush MaterializedOutputBuffer partition buffers to the writer;
+  /// (2) wait for writer background threads to drain packages to network.
+  ///
+  /// Priority kHighReclaimPriority ensures this pool is reclaimed before
+  /// operator pools (priority 0+).
+  class Reclaimer : public velox::exec::MemoryReclaimer {
+   public:
+    static constexpr int32_t kHighReclaimPriority = -1;
+
+    explicit Reclaimer(MaterializedOutputBuffer* partitionBuffer);
+
+    bool reclaimableBytes(
+        const velox::memory::MemoryPool& pool,
+        uint64_t& reclaimableBytes) const override;
+
+    uint64_t reclaim(
+        velox::memory::MemoryPool* pool,
+        uint64_t targetBytes,
+        uint64_t maxWaitMs,
+        Stats& stats) override;
+
+   private:
+    /// Returns true if the pool has reclaimable bytes and the buffer
+    /// is in a state that supports reclaim (kActive or kDraining).
+    bool canReclaim(const velox::memory::MemoryPool& pool, uint64_t targetBytes)
+        const;
+
+    /// Returns true if partition flush should run: kActive state and
+    /// bufferedBytes > 0. During kDraining, noMoreData() is already
+    /// draining partitions so we skip to waiting for writer drain.
+    bool canReclaimFromPartitionBuffers() const;
+
+    /// Flush partition buffers to the writer. Calls tryDrainPartitions()
+    /// which sorts partitions largest-first and flushes each above
+    /// reclaimDrainThresholdBytes via try_lock.
+    void tryReclaimPartitionBuffers(velox::memory::MemoryPool* pool);
+
+    /// Wait for writer background threads to drain packages to network.
+    /// Polls pool->usedBytes() every 10ms until the pool reaches
+    /// targetUsedBytes or the deadline expires.
+    void waitForWriterDrain(
+        velox::memory::MemoryPool* pool,
+        uint64_t targetUsedBytes,
+        std::chrono::steady_clock::time_point deadline);
+
+    /// Update arbitrator stats and buffer reclaim counters.
+    void recordStats(uint64_t freedBytes, Stats& stats);
+
+    MaterializedOutputBuffer* const partitionBuffer_;
+  };
 
   /// Creates its own leaf pool under 'parentPool' and the writer from
   /// the factory.
@@ -82,14 +142,22 @@ class MaterializedOutputBuffer {
       const std::string& shuffleWriterInfo,
       ShuffleInterfaceFactory* shuffleWriterFactory,
       const std::string& taskId,
-      int64_t maxBufferedBytes,
-      velox::memory::MemoryPool* pool,
-      int64_t partitionDrainThreshold = 0);
+      velox::memory::MemoryPool* pool);
 
   ~MaterializedOutputBuffer();
 
   /// Enqueue a serialized RowGroup for a partition.
   void enqueue(int32_t partition, std::unique_ptr<folly::IOBuf> rowGroup);
+
+  /// Best-effort drain for reclaim. Uses try_lock — skips contested
+  /// partitions to avoid deadlock with enqueue() -> collect() ->
+  /// arbitration. Partitions below reclaimDrainThresholdBytes() are skipped.
+  uint64_t tryDrainPartitions();
+
+  /// Minimum partition bytes worth flushing during reclaim.
+  int64_t reclaimDrainThresholdBytes() const {
+    return reclaimDrainThresholdBytes_;
+  }
 
   /// Signal that no more data will be enqueued. Drains remaining data
   /// and calls writer->noMoreData(true).
@@ -152,7 +220,7 @@ class MaterializedOutputBuffer {
 
     mutable std::mutex mutex_;
     std::deque<std::unique_ptr<folly::IOBuf>> rowGroups_;
-    int64_t bufferedBytes_{0};
+    std::atomic_int64_t bufferedBytes_{0};
     int64_t drainThreshold_{0};
     // Per-partition safety net: set under the partition lock by
     // drainPartition(close=true). Guards against data loss if enqueue
@@ -162,12 +230,19 @@ class MaterializedOutputBuffer {
     MaterializedOutputBuffer* buffer_{nullptr};
   };
 
-  /// Drains buffered data for a partition. If close=true, marks the
-  /// partition closed under its lock.
-  int64_t drainPartition(int32_t partition, bool close = false);
+  /// Initialize partition buffers and validate invariants.
+  void initPartitionBuffers(int32_t numPartitions);
+
+  /// Drain buffered data for a single partition. When force=false (default),
+  /// uses try_lock and returns 0 if the partition mutex is contested. When
+  /// force=true, uses blocking lock and marks the partition closed.
+  int64_t drainPartition(int32_t partition, bool force = false);
 
   /// Drains all partitions and marks them closed.
   uint64_t close();
+
+  /// Update drain stats and subtract from buffered bytes counter.
+  void updateDrainStats(int64_t drainedBytes);
 
   // Coalesce data into a contiguous buffer and send to the ShuffleWriter.
   void flushToWriter(int32_t partition, std::unique_ptr<folly::IOBuf> data);
@@ -183,6 +258,7 @@ class MaterializedOutputBuffer {
   const int32_t numPartitions_;
   const int64_t maxBufferedBytes_;
   const int64_t partitionDrainThreshold_;
+  const int64_t reclaimDrainThresholdBytes_;
 
   // Pool created first so the writer can allocate from it.
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -192,14 +268,16 @@ class MaterializedOutputBuffer {
 
   // Per-partition buffers. Each PartitionBuffer has its own mutex that
   // serializes enqueue + drain for that partition.
-  std::atomic<int64_t> bufferedBytes_{0};
+  std::atomic_int64_t bufferedBytes_{0};
   std::vector<std::unique_ptr<PartitionBuffer>> partitionBuffers_;
 
   // Stats counters.
-  std::atomic<int64_t> totalDrainedBytes_{0};
-  std::atomic<int64_t> drainCount_{0};
-  std::atomic<int64_t> peakBufferedBytes_{0};
-  std::atomic<int64_t> lastLoggedDrainedGB_{0};
+  std::atomic_int64_t drainedBytes_{0};
+  std::atomic_int64_t drainCount_{0};
+  std::atomic_int64_t peakBufferedBytes_{0};
+  std::atomic_int64_t reclaimCount_{0};
+  std::atomic_int64_t reclaimedBytes_{0};
+  std::atomic_int64_t lastLoggedDrainedGB_{0};
   std::vector<std::atomic<int64_t>> collectCountPerPartition_;
 };
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -74,3 +74,23 @@ target_link_libraries(
 set_tests_properties(presto_materialized_exchange_test PROPERTIES TIMEOUT 300)
 
 set_property(TARGET presto_materialized_exchange_test PROPERTY JOB_POOL_LINK presto_link_job_pool)
+
+add_executable(presto_materialized_exchange_reclaim_test MaterializedExchangeReclaimTest.cpp)
+
+add_test(
+  NAME presto_materialized_exchange_reclaim_test
+  COMMAND presto_materialized_exchange_reclaim_test
+)
+
+target_link_libraries(
+  presto_materialized_exchange_reclaim_test
+  presto_operators
+  velox_exec
+  velox_memory
+  GTest::gtest
+)
+
+set_property(
+  TARGET presto_materialized_exchange_reclaim_test
+  PROPERTY JOB_POOL_LINK presto_link_job_pool
+)

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeReclaimTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeReclaimTest.cpp
@@ -1,0 +1,341 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "presto_cpp/main/operators/MaterializedOutputBuffer.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::velox;
+using namespace facebook::presto::operators;
+
+namespace facebook::presto::operators::test {
+
+using Reclaimer = MaterializedOutputBuffer::Reclaimer;
+
+constexpr int64_t kMB = 1L << 20;
+
+namespace {
+
+class NoOpShuffleWriter : public ShuffleWriter {
+ public:
+  void collect(int32_t, std::string_view, std::string_view) override {}
+  void noMoreData(bool) override {}
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return {};
+  }
+};
+
+class NoOpShuffleFactory : public ShuffleInterfaceFactory {
+ public:
+  std::shared_ptr<ShuffleReader> createReader(
+      const std::string&,
+      int32_t,
+      velox::memory::MemoryPool*) override {
+    VELOX_UNSUPPORTED();
+  }
+  std::shared_ptr<ShuffleWriter> createWriter(
+      const std::string&,
+      velox::memory::MemoryPool*) override {
+    return std::make_shared<NoOpShuffleWriter>();
+  }
+};
+
+} // namespace
+
+class ReclaimerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    memory::MemoryManager::testingSetInstance({});
+    rootPool_ = memory::memoryManager()->addRootPool(
+        "reclaimerTest", 256 * kMB, memory::MemoryReclaimer::create());
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+};
+
+TEST_F(ReclaimerTest, emptyPoolReturnsImmediately) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  uint64_t reclaimableBytes = 0;
+  EXPECT_FALSE(reclaimer.reclaimableBytes(*buffer.pool(), reclaimableBytes));
+  EXPECT_EQ(reclaimableBytes, 0);
+
+  memory::MemoryReclaimer::Stats stats;
+  EXPECT_EQ(reclaimer.reclaim(buffer.pool(), 10 * kMB, 5000, stats), 0);
+}
+
+TEST_F(ReclaimerTest, reclaimableReportsPoolUsage) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(10 * kMB);
+
+  uint64_t reclaimableBytes = 0;
+  EXPECT_TRUE(reclaimer.reclaimableBytes(*buffer.pool(), reclaimableBytes));
+  EXPECT_EQ(reclaimableBytes, 10 * kMB);
+
+  buffer.pool()->free(allocation, 10 * kMB);
+}
+
+TEST_F(ReclaimerTest, fullDrainFromBackgroundThread) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(10 * kMB);
+
+  std::thread drainer([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    buffer.pool()->free(allocation, 10 * kMB);
+  });
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 5000, stats);
+  drainer.join();
+
+  EXPECT_EQ(freedBytes, 10 * kMB);
+  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
+}
+
+TEST_F(ReclaimerTest, partialDrainBeforeTimeout) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation1 = buffer.pool()->allocate(5 * kMB);
+  void* allocation2 = buffer.pool()->allocate(5 * kMB);
+
+  std::thread drainer([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    buffer.pool()->free(allocation1, 5 * kMB);
+  });
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 200, stats);
+  drainer.join();
+
+  EXPECT_EQ(freedBytes, 5 * kMB);
+  EXPECT_EQ(buffer.pool()->usedBytes(), 5 * kMB);
+
+  buffer.pool()->free(allocation2, 5 * kMB);
+}
+
+TEST_F(ReclaimerTest, timeoutReturnsZeroWhenNothingDrains) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(10 * kMB);
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 100, stats);
+
+  EXPECT_EQ(freedBytes, 0);
+  EXPECT_EQ(buffer.pool()->usedBytes(), 10 * kMB);
+
+  buffer.pool()->free(allocation, 10 * kMB);
+}
+
+TEST_F(ReclaimerTest, zeroWaitReturnsImmediately) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(10 * kMB);
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 0, stats);
+
+  EXPECT_EQ(freedBytes, 0);
+
+  buffer.pool()->free(allocation, 10 * kMB);
+}
+
+TEST_F(ReclaimerTest, targetLargerThanUsage) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(5 * kMB);
+
+  std::thread drainer([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    buffer.pool()->free(allocation, 5 * kMB);
+  });
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 100 * kMB, 5000, stats);
+  drainer.join();
+
+  EXPECT_EQ(freedBytes, 5 * kMB);
+  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
+}
+
+TEST_F(ReclaimerTest, incrementalDrain) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation1 = buffer.pool()->allocate(3 * kMB);
+  void* allocation2 = buffer.pool()->allocate(3 * kMB);
+  void* allocation3 = buffer.pool()->allocate(4 * kMB);
+
+  std::thread drainer([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    buffer.pool()->free(allocation1, 3 * kMB);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    buffer.pool()->free(allocation2, 3 * kMB);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    buffer.pool()->free(allocation3, 4 * kMB);
+  });
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 5000, stats);
+  drainer.join();
+
+  EXPECT_EQ(freedBytes, 10 * kMB);
+  EXPECT_EQ(buffer.pool()->usedBytes(), 0);
+}
+
+TEST_F(ReclaimerTest, consecutiveReclaims) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation1 = buffer.pool()->allocate(5 * kMB);
+
+  std::thread drainer1([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    buffer.pool()->free(allocation1, 5 * kMB);
+  });
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes1 = reclaimer.reclaim(buffer.pool(), 5 * kMB, 5000, stats);
+  drainer1.join();
+  EXPECT_EQ(freedBytes1, 5 * kMB);
+
+  void* allocation2 = buffer.pool()->allocate(8 * kMB);
+
+  std::thread drainer2([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    buffer.pool()->free(allocation2, 8 * kMB);
+  });
+
+  auto freedBytes2 = reclaimer.reclaim(buffer.pool(), 8 * kMB, 5000, stats);
+  drainer2.join();
+  EXPECT_EQ(freedBytes2, 8 * kMB);
+}
+
+TEST_F(ReclaimerTest, reclaimSkippedAfterClose) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(10 * kMB);
+
+  buffer.noMoreData();
+  EXPECT_EQ(buffer.state(), MaterializedOutputBuffer::State::kClosed);
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 100, stats);
+  EXPECT_EQ(freedBytes, 0);
+
+  buffer.pool()->free(allocation, 10 * kMB);
+}
+
+TEST_F(ReclaimerTest, reclaimBlockedWhenAborted) {
+  NoOpShuffleFactory factory;
+  MaterializedOutputBuffer buffer(
+      /*numPartitions=*/1,
+      /*shuffleWriterInfo=*/"",
+      &factory,
+      "test.0.0.0.0",
+      rootPool_.get());
+  Reclaimer reclaimer(&buffer);
+
+  void* allocation = buffer.pool()->allocate(10 * kMB);
+
+  buffer.abort();
+  EXPECT_EQ(buffer.state(), MaterializedOutputBuffer::State::kAborted);
+
+  memory::MemoryReclaimer::Stats stats;
+  auto freedBytes = reclaimer.reclaim(buffer.pool(), 10 * kMB, 100, stats);
+  EXPECT_EQ(freedBytes, 0);
+
+  buffer.pool()->free(allocation, 10 * kMB);
+}
+
+} // namespace facebook::presto::operators::test
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init follyInit{&argc, &argv, false};
+  return RUN_ALL_TESTS();
+}

--- a/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/MaterializedExchangeTest.cpp
@@ -16,6 +16,8 @@
 
 #include <boost/range/algorithm/find_if.hpp>
 
+#include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/common/tests/MutableConfigs.h"
 #include "presto_cpp/main/operators/LocalShuffle.h"
 #include "presto_cpp/main/operators/MaterializedExchange.h"
 #include "presto_cpp/main/operators/MaterializedOutput.h"
@@ -218,13 +220,11 @@ class MaterializedExchangeTest : public exec::test::OperatorTestBase {
     auto dataType = asRowType(data[0]->type());
     auto writeInfoStr =
         localShuffleWriteInfo(tempDir_->getPath(), numPartitions);
-    constexpr size_t kMaxBufferedBytes = 1 << 20; // 1MB
     auto buffer = std::make_shared<MaterializedOutputBuffer>(
         numPartitions,
         writeInfoStr,
         ShuffleInterfaceFactory::factory(shuffleName_),
         "test.0.0.0.0",
-        kMaxBufferedBytes,
         rootPool_.get());
 
     // Build partition key expressions on column 0.
@@ -430,14 +430,21 @@ TEST_F(MaterializedExchangeTest, bufferMemoryTracking) {
   auto shuffleDir = exec::test::TempDirectoryPath::create();
   auto writeInfo = localShuffleWriteInfo(shuffleDir->getPath(), numPartitions);
 
+  facebook::presto::test::setupMutableSystemConfig();
+  SystemConfig::instance()->setValue(
+      std::string(
+          SystemConfig::
+              kExchangeMaterializationOutputBufferPerPartitionMaxBytes),
+      "51200");
+  SystemConfig::instance()->setValue(
+      std::string(SystemConfig::kExchangeMaterializationOutputBufferMaxBytes),
+      std::to_string(100L * 1024 * 1024));
   auto buffer = std::make_shared<MaterializedOutputBuffer>(
       numPartitions,
       writeInfo,
       ShuffleInterfaceFactory::factory(shuffleName_),
       "memtest.0.0.0.0",
-      /*maxBufferedBytes=*/100L * 1024 * 1024,
-      rootPool.get(),
-      /*partitionDrainThreshold=*/50L * 1024);
+      rootPool.get());
 
   // Enqueue 10KB per partition across many rounds. Pool has 2MB, drain
   // threshold is 50KB so partitions won't drain until 50KB accumulated.
@@ -572,13 +579,11 @@ TEST_F(MaterializedExchangeTest, assertBufferCloseExceptionsArePropagated) {
   auto* realFactory = ShuffleInterfaceFactory::factory(shuffleName_);
   FailingCloseShuffleFactory failingFactory(realFactory);
 
-  constexpr size_t kMaxBufferedBytes = 1 << 20;
   auto buffer = std::make_shared<MaterializedOutputBuffer>(
       numPartitions,
       writeInfoStr,
       &failingFactory,
       "failtest.0.0.0.0",
-      kMaxBufferedBytes,
       rootPool_.get());
 
   std::vector<core::TypedExprPtr> keys{
@@ -623,7 +628,6 @@ TEST_F(MaterializedExchangeTest, enqueueAfterNoMoreDataThrows) {
       writeInfo,
       ShuffleInterfaceFactory::factory(shuffleName_),
       "test.0.0.0.0",
-      /*maxBufferedBytes=*/1L << 20,
       rootPool.get());
 
   auto iobuf = buffer->allocateTrackedIOBuf(1024);
@@ -657,7 +661,6 @@ TEST_F(MaterializedExchangeTest, abortFromActiveState) {
       writeInfo,
       ShuffleInterfaceFactory::factory(shuffleName_),
       "test.0.0.0.0",
-      /*maxBufferedBytes=*/1L << 20,
       rootPool.get());
 
   auto iobuf = buffer->allocateTrackedIOBuf(1024);

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -39,7 +39,6 @@
 #include "presto_cpp/main/operators/ShuffleWrite.h"
 #include "presto_cpp/main/properties/session/SessionProperties.h"
 #include "presto_cpp/main/types/TypeParser.h"
-#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/TraceUtil.h"
 // RPC plan nodes for single-operator async RPC execution
 #include <folly/json.h>
@@ -2645,19 +2644,12 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
         shuffleFactory,
         "ShuffleInterface factory '{}' not registered",
         shuffleName_);
-    const auto maxBufferedBytes =
-        SystemConfig::instance()->exchangeMaterializationOutputBufferMaxBytes();
-    const auto drainThreshold =
-        SystemConfig::instance()
-            ->exchangeMaterializationOutputBufferPerPartitionMaxBytes();
     auto buffer = std::make_shared<operators::MaterializedOutputBuffer>(
         partitionedOutputNode->numPartitions(),
         *serializedShuffleWriteInfo_,
         shuffleFactory,
         taskId,
-        maxBufferedBytes,
-        queryCtx_->pool(),
-        drainThreshold);
+        queryCtx_->pool());
 
     auto materializedOutputNode =
         std::make_shared<operators::MaterializedOutputNode>(


### PR DESCRIPTION
…er (#27875)

Summary:
Pull Request resolved: https://github.com/prestodb/presto/pull/27875

## Overview

Adds two-phase memory reclaim for MaterializedOutputBuffer, integrated with the Velox memory arbitrator. When the arbitrator needs to free memory, the Reclaimer flushes partition buffers to the ShuffleWriter and waits for network drain.

## Two-Phase Reclaim

```
Velox Memory Arbitrator
  |
  v
Reclaimer::reclaim(pool, targetBytes, maxWaitMs)
  |
  |-- canReclaim(pool, targetBytes)?
  |     - false if targetBytes == 0, pool empty, or state is kClosed/kAborted
  |     - true for kActive (both phases) and kDraining (Phase 2 only)
  |
  |-- Phase 1: FLUSH partition buffers (kActive only)
  |     canReclaimFromPartitionBuffers()?
  |       - true only if kActive AND bufferedBytes > 0
  |     tryDrainPartitions():
  |       1. Snapshot partition sizes via atomic bufferedBytes (lock-free)
  |       2. Sort partitions largest-first
  |       3. Skip partitions below reclaimDrainThresholdBytes
  |       4. tryDrainPartition(): try_lock -> swap buffers -> unlock
  |          -> coalesce + flush outside lock
  |     Early return if poolUsedBytes <= poolTargetBytes
  |
  |-- Phase 2: WAIT for writer network drain
  |     waitForWriterDrain(pool, poolTargetBytes, deadline):
  |       Poll pool->usedBytes() every 10ms until target or deadline
  |
  |-- totalFreedBytes = poolStartBytes - pool->usedBytes()
  |-- recordStats(totalFreedBytes)
```

## State-Aware Dispatch

| State | canReclaim | canReclaimFromPartitionBuffers | Behavior | |-------|-----------|-------------------------------|----------| | kActive | true | true (if bufferedBytes > 0) | Phase 1 + Phase 2 | | kDraining | true | false | Phase 2 only (noMoreData is flushing, reclaim waits for network) | | kClosed | false | N/A | return 0 (buffer fully drained) | | kAborted | false | N/A | return 0 (error teardown) |

The kDraining scenario occurs when `noMoreData()` calls `close()` which calls `coalesceRowGroups() -> allocateTrackedIOBuf()`. That allocation can trigger arbitration -> reclaim on the same pool. Since the partition buffers are already being drained by `noMoreData()`, Phase 1 is skipped and reclaim only waits for the writer to drain packages to network.

## Deadlock Prevention

The reclaimer uses `try_lock` on partition mutexes instead of blocking locks. If a partition lock is held by `enqueue()` (which may call `writer->collect()` -> allocation -> arbitration -> reclaim), `tryDrainPartition` skips it and moves on. The contested partition is self-draining via its own enqueue threshold.

Coalesce and flush happen outside the try_lock to avoid holding the partition mutex across pool allocations and writer calls. This matches the pattern used by `drainPartition()`. Safe because reclaim is single-threaded (the arbitrator pauses the triggering driver) and Velox prevents re-entrant arbitration on the same thread.

## Bytes Accounting

Single-baseline approach: `poolStartBytes` captured once at entry, `poolTargetBytes` computed once as `poolStartBytes - targetBytes`. Phase 1 and Phase 2 just do work (void functions). `totalFreedBytes` measured once at the end: `poolStartBytes - pool->usedBytes()`. No bytes passed between functions.

## Configurable Reclaim Drain Threshold

New config `exchange.materialization.reclaim-drain-threshold-ratio` (default 0.67). The reclaim drain threshold is `partitionDrainThreshold * ratio` -- generally lower than the regular drain threshold, but high enough that draining actually reduces memory. Without this lower bound, reclaim would flush small partition buffers that produce data too small for the writer to compress efficiently -- low ROI flushes.

## Key Components

- `Reclaimer` class: nested inside MaterializedOutputBuffer, registered with `kHighReclaimPriority = -1` (reclaimed before operator pools). Requires non-null `partitionBuffer_` (enforced by `VELOX_CHECK_NOT_NULL`).
- `canReclaim(pool, targetBytes)`: gates the entire reclaim call
- `canReclaimFromPartitionBuffers()`: gates Phase 1 (kActive + bufferedBytes > 0)
- `tryDrainPartitions()` / `tryDrainPartition()`: Phase 1 implementation
- `waitForWriterDrain(pool, poolTargetBytes, deadline)`: Phase 2 implementation
- `updateDrainStats(drainedBytes)`: shared helper for drain count, drained bytes, and buffered bytes accounting
- `MATERIALIZED_BUFFER_LOG` macro: structured logging with pool name and `velox::succinctBytes`
- `reclaimDrainThresholdBytes_`: precomputed in constructor from config
- Per-partition `bufferedBytes_` is `std::atomic<int64_t>` for lock-free size snapshots during reclaim sorting
- All config values (`maxBufferedBytes`, `partitionDrainThreshold`, `reclaimDrainThresholdRatio`) read from SystemConfig inside the constructor

Reviewed By: xiaoxmeng

Differential Revision: D106394830

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

